### PR TITLE
Default light mode

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -52,9 +52,14 @@ class _MyAppState extends State<MyApp> {
       builder: (context, snapshot) {
         if (snapshot.connectionState == ConnectionState.done) {
           final SharedPreferences prefs = SharedPrefs.prefs;
+          //set theme to light if not set
+          if (prefs.getString('theme') == null) {
+            prefs.setString('theme', 'light');
+          }
           final brightness = switch (prefs.getString('theme')) {
             "dark" => Brightness.dark,
             "light" => Brightness.light,
+            "system" => MediaQuery.platformBrightnessOf(context),
             _ => Brightness.light,
           };
           return Theme(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -55,7 +55,7 @@ class _MyAppState extends State<MyApp> {
           final brightness = switch (prefs.getString('theme')) {
             "dark" => Brightness.dark,
             "light" => Brightness.light,
-            _ => MediaQuery.platformBrightnessOf(context)
+            _ => Brightness.light,
           };
           return Theme(
         data: ThemeData(

--- a/lib/screens/settings/settings.dart
+++ b/lib/screens/settings/settings.dart
@@ -113,6 +113,47 @@ class _SettingsState extends State<Settings> {
     );
   }
 
+  _showThemeSelectionDialog(BuildContext context) {
+    showCupertinoModalPopup(
+      context: context,
+      builder: (BuildContext context) => CupertinoActionSheet(
+        title: const Text('Select Theme'),
+        actions: [
+          CupertinoActionSheetAction(
+            onPressed: () {
+              SharedPrefs.prefs.setString('theme', 'light');
+              Navigator.pop(context);
+              setState(() {});
+            },
+            child: const Text('Light'),
+          ),
+          CupertinoActionSheetAction(
+            onPressed: () {
+              SharedPrefs.prefs.setString('theme', 'dark');
+              Navigator.pop(context);
+              setState(() {});
+            },
+            child: const Text('Dark'),
+          ),
+          CupertinoActionSheetAction(
+            onPressed: () {
+              SharedPrefs.prefs.setString('theme', 'system');
+              Navigator.pop(context);
+              setState(() {});
+            },
+            child: const Text('System'),
+          ),
+        ],
+        cancelButton: CupertinoActionSheetAction(
+          onPressed: () {
+            Navigator.pop(context);
+          },
+          child: const Text('Cancel'),
+        ),
+      ),
+    );
+  }
+
   static const String backupFailedMessage =
       "backup failed  (Folder may be protected. Try using the documents directory)";
   @override
@@ -242,19 +283,17 @@ class _SettingsState extends State<Settings> {
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [
                       const Text("Dark mode (requires app restart)"),
-                      CupertinoSwitch(
-                        value: switch (SharedPrefs.prefs.getString('theme')) {
-                          "dark" => true,
-                          "light" => false,
-                          _ => MediaQuery.platformBrightnessOf(context) ==
-                              Brightness.dark
+                      CupertinoButton(
+                        onPressed: () {
+                          _showThemeSelectionDialog(context);
                         },
-                        activeTrackColor: CupertinoColors.activeBlue,
-                        onChanged: (bool value) {
-                          SharedPrefs.prefs.setString(
-                              'theme', value ? 'dark' : 'light');
-                          setState(() {});
-                        },
+                        child: Text(
+                          switch (SharedPrefs.prefs.getString('theme')) {
+                            "dark" => "Dark",
+                            "light" => "Light",
+                            _ => "System",
+                          },
+                        ),
                       ),
                     ],
                   ),


### PR DESCRIPTION
Dark mode support was added in #14. While it looks good on most screens it's also not the one I mainly use which makes it somewhat difficult to maintain. Instead dark mode will be stay as a feature in settings, and users can chose one of light, dark and system, with light being the default. cc @Data-Praetor.